### PR TITLE
Add basic Home page with cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,9 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Home Page
+
+A new responsive Home page lives in `src/app/home/page.tsx`. It lists vocabulary units in cards using ShadCN UI components and a reusable `UnitCard` component (`src/components/UnitCard.tsx`).
+
+Run the dev server and open [http://localhost:3000/home](http://localhost:3000/home) to view it.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-progress": "^1.1.7",
+    "@radix-ui/react-avatar": "^1.0.6",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.12",
     "class-variance-authority": "^0.7.1",

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,0 +1,41 @@
+import UnitCard from "@/components/UnitCard";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+const units = [
+  { id: 1, title: "Oxford Word Skill", subtitle: "Basic vocabulary", progress: 45, learned: 120 },
+  { id: 2, title: "Oxford Word Skill", subtitle: "Intermediate vocabulary", progress: 10, learned: 30 },
+  { id: 3, title: "Oxford Word Skill", subtitle: "Advanced vocabulary", progress: 0, learned: 0 },
+];
+
+export default function HomePage() {
+  return (
+    <main className="min-h-screen flex flex-col pb-16">
+      <header className="p-4 flex justify-end">
+        <Avatar>
+          <AvatarFallback>U</AvatarFallback>
+        </Avatar>
+      </header>
+      <div className="flex-1 flex flex-col gap-4 p-4">
+        {units.map((unit) => (
+          <UnitCard
+            key={unit.id}
+            title={unit.title}
+            subtitle={unit.subtitle}
+            progress={unit.progress}
+            learnedWords={unit.learned}
+          />
+        ))}
+      </div>
+      <nav className="fixed bottom-0 left-0 right-0 border-t bg-background">
+        <Tabs defaultValue="home" className="w-full">
+          <TabsList className="grid grid-cols-3 w-full rounded-none">
+            <TabsTrigger value="home">Home</TabsTrigger>
+            <TabsTrigger value="units">Units</TabsTrigger>
+            <TabsTrigger value="library">Library</TabsTrigger>
+          </TabsList>
+        </Tabs>
+      </nav>
+    </main>
+  );
+}

--- a/src/components/UnitCard.tsx
+++ b/src/components/UnitCard.tsx
@@ -1,0 +1,35 @@
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter, CardAction } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+
+interface UnitCardProps {
+  title: string;
+  subtitle: string;
+  progress: number;
+  learnedWords: number;
+}
+
+export default function UnitCard({ title, subtitle, progress, learnedWords }: UnitCardProps) {
+  return (
+    <Card className="w-full max-w-md mx-auto">
+      <CardHeader className="border-b">
+        <div>
+          <CardTitle>{title}</CardTitle>
+          <CardDescription>{subtitle}</CardDescription>
+        </div>
+        <CardAction>
+          <div className="border-2 rounded-full size-12 flex items-center justify-center text-sm">
+            {progress}%
+          </div>
+        </CardAction>
+      </CardHeader>
+      <CardContent className="space-y-2 py-4">
+        <Progress value={progress} />
+        <p className="text-sm text-muted-foreground">{learnedWords} words learned</p>
+      </CardContent>
+      <CardFooter>
+        <Button className="ml-auto">Continue</Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import * as React from "react"
+import * as AvatarPrimitive from "@radix-ui/react-avatar"
+
+import { cn } from "@/lib/utils"
+
+const Avatar = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
+      className
+    )}
+    {...props}
+  />
+))
+Avatar.displayName = AvatarPrimitive.Root.displayName
+
+const AvatarImage = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Image>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Image
+    ref={ref}
+    className={cn("aspect-square h-full w-full", className)}
+    {...props}
+  />
+))
+AvatarImage.displayName = AvatarPrimitive.Image.displayName
+
+const AvatarFallback = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Fallback
+    ref={ref}
+    className={cn(
+      "flex h-full w-full items-center justify-center rounded-full bg-muted",
+      className
+    )}
+    {...props}
+  />
+))
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName
+
+export { Avatar, AvatarImage, AvatarFallback }


### PR DESCRIPTION
## Summary
- implement `Avatar` UI component
- add `UnitCard` reusable component
- create `/home` route displaying vocabulary units
- document the new Home page usage
- include `@radix-ui/react-avatar` dependency

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68711d9faf8c8326b6f8b62fa5a053ec